### PR TITLE
Add CRM payload forwarding to WhatsApp webhook

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Servidor Express listo para desplegar en [Render](https://render.com) que expone
    - `WHATSAPP_VERIFY_TOKEN`: Token de verificación que configuraste en Meta para validar el Webhook. Si no defines ninguno, el servidor utilizará por defecto `ReLead_Verify_Token`.
    - `WHATSAPP_ACCESS_TOKEN`: Token de acceso a la API de WhatsApp Cloud.
    - `WHATSAPP_PHONE_NUMBER_ID`: ID del número de teléfono de WhatsApp Cloud.
+   - `CRM_WEBHOOK_URL` (opcional): URL a la que se enviarán los datos enriquecidos del webhook para sincronizarlos con tu CRM. Si ya cuentas con `API_URL` para tu backend de CRM, puedes omitir esta variable y se reutilizará automáticamente.
+   - `CRM_API_KEY` (opcional): Token que se incluirá en la cabecera `Authorization` al sincronizar con el CRM.
 
 2. Instala dependencias:
 
@@ -26,7 +28,17 @@ Servidor Express listo para desplegar en [Render](https://render.com) que expone
 
 - `GET /` devuelve un mensaje de estado.
 - `GET /webhook` gestiona la verificación de Meta (necesario para conectar el Webhook).
-- `POST /webhook` recibe mensajes entrantes y, si hay credenciales configuradas, responde con un mensaje de eco.
+- `POST /webhook` recibe mensajes entrantes, estructura la información relevante (contacto, contenido, adjuntos y estados) y la envía al CRM configurado. Si hay credenciales de WhatsApp, responde con un mensaje de eco.
+
+## Integración con CRM
+
+Cuando se recibe un evento de WhatsApp Cloud API, el servidor genera un payload con los datos necesarios para mostrarlos en un CRM:
+
+- Datos de contacto (WA ID y nombre de perfil).
+- Mensajes recibidos con contenido de texto, botones, interacciones y metadatos de archivos o ubicaciones.
+- Estados de mensajes (entregado, leído, etc.) con información de conversación y costos.
+
+Si configuras `CRM_WEBHOOK_URL`, el payload se enviará mediante `POST` en formato JSON al endpoint que elijas. Si prefieres reutilizar una variable existente, establece `API_URL` con la URL de tu CRM y el webhook la usará automáticamente. Puedes proteger la integración con `CRM_API_KEY` (se enviará como `Authorization: Bearer <token>`). Si no defines ninguna de las URLs, el proceso se omitirá automáticamente y el webhook seguirá respondiendo a Meta.
 
 ## Despliegue en Render
 

--- a/webhook.js
+++ b/webhook.js
@@ -6,6 +6,8 @@ const port = process.env.PORT || 3000;
 const verifyToken = process.env.WHATSAPP_VERIFY_TOKEN || 'ReLead_Verify_Token';
 const accessToken = process.env.WHATSAPP_ACCESS_TOKEN;
 const phoneNumberId = process.env.WHATSAPP_PHONE_NUMBER_ID;
+const crmWebhookUrl = process.env.CRM_WEBHOOK_URL || process.env.API_URL;
+const crmApiKey = process.env.CRM_API_KEY;
 
 if (!accessToken || !phoneNumberId) {
   console.warn('WHATSAPP_ACCESS_TOKEN or WHATSAPP_PHONE_NUMBER_ID is missing. Automated replies are disabled.');
@@ -42,6 +44,11 @@ app.post('/webhook', async (req, res) => {
     const changes = entry?.changes?.[0];
     const value = changes?.value;
     const message = value?.messages?.[0];
+
+    if (value) {
+      const crmPayload = buildCrmPayload(value);
+      await sendDataToCrm(crmPayload);
+    }
 
     if (message) {
       console.log('Incoming message:', JSON.stringify(message, null, 2));
@@ -87,6 +94,129 @@ async function sendWhatsAppText(to, text) {
       'Content-Type': 'application/json'
     }
   });
+}
+
+function buildCrmPayload(value) {
+  const contact = value?.contacts?.[0] || {};
+  const messages = (value?.messages || []).map((msg) => buildCrmMessage(msg));
+  const statuses = (value?.statuses || []).map((status) => ({
+    id: status.id,
+    status: status.status,
+    timestamp: status.timestamp,
+    recipientId: status.recipient_id,
+    conversation: status.conversation,
+    pricing: status.pricing,
+    errors: status.errors
+  }));
+  const firstStatusRecipient = value?.statuses?.[0]?.recipient_id;
+
+  return {
+    contact: {
+      waId: contact.wa_id || messages[0]?.from || firstStatusRecipient || null,
+      profileName: contact.profile?.name || null
+    },
+    metadata: value?.metadata,
+    messages,
+    statuses
+  };
+}
+
+function buildCrmMessage(msg = {}) {
+  const base = {
+    id: msg.id,
+    from: msg.from,
+    timestamp: msg.timestamp,
+    type: msg.type
+  };
+
+  if (msg.text?.body) {
+    base.text = msg.text.body;
+  }
+
+  if (msg.button?.text) {
+    base.buttonText = msg.button.text;
+  }
+
+  if (msg.interactive) {
+    base.interactive = {
+      type: msg.interactive.type,
+      buttonReply: msg.interactive.button_reply,
+      listReply: msg.interactive.list_reply
+    };
+  }
+
+  const media = extractMediaInfo(msg);
+  if (media) {
+    base.media = media;
+  }
+
+  if (msg.context) {
+    base.context = {
+      id: msg.context.id,
+      from: msg.context.from
+    };
+  }
+
+  return base;
+}
+
+function extractMediaInfo(msg = {}) {
+  const mediaTypes = ['image', 'audio', 'document', 'video', 'sticker'];
+
+  for (const type of mediaTypes) {
+    if (msg[type]) {
+      return {
+        type,
+        id: msg[type].id,
+        mimeType: msg[type].mime_type,
+        sha256: msg[type].sha256,
+        caption: msg[type].caption
+      };
+    }
+  }
+
+  if (msg.location) {
+    return {
+      type: 'location',
+      latitude: msg.location.latitude,
+      longitude: msg.location.longitude,
+      name: msg.location.name,
+      address: msg.location.address
+    };
+  }
+
+  return null;
+}
+
+async function sendDataToCrm(payload) {
+  if (!payload) {
+    return;
+  }
+
+  if (!crmWebhookUrl) {
+    console.log('CRM webhook URL is not configured. Skipping CRM sync.');
+    return;
+  }
+
+  const hasMessages = Array.isArray(payload.messages) && payload.messages.length > 0;
+  const hasStatuses = Array.isArray(payload.statuses) && payload.statuses.length > 0;
+
+  if (!hasMessages && !hasStatuses) {
+    console.log('No CRM data to send.');
+    return;
+  }
+
+  try {
+    await axios.post(crmWebhookUrl, payload, {
+      headers: {
+        'Content-Type': 'application/json',
+        ...(crmApiKey ? { Authorization: `Bearer ${crmApiKey}` } : {})
+      }
+    });
+    console.log('CRM payload sent successfully');
+  } catch (error) {
+    console.error('Error sending data to CRM:', error?.response?.data || error.message);
+  }
 }
 
 app.listen(port, () => {


### PR DESCRIPTION
## Summary
- enrich incoming WhatsApp webhook events with structured contact, message, and status data for CRM consumption
- forward the normalized payload to an optional CRM webhook with bearer auth support (reusing `API_URL` when `CRM_WEBHOOK_URL` is not provided)
- document the new CRM configuration variables and the CRM URL fallback in the README

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d43dde2f00832c9a90423776be0758