### PR TITLE
Hardcode CRM webhook URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Servidor Express listo para desplegar en [Render](https://render.com) que expone
    - `PORT`: Puerto en el que se ejecutará el servidor (Render lo define automáticamente).
    - `WHATSAPP_VERIFY_TOKEN`: Token de verificación que configuraste en Meta para validar el Webhook. Si no defines ninguno, el servidor utilizará por defecto `ReLead_Verify_Token`.
    - `WHATSAPP_ACCESS_TOKEN`: Token de acceso a la API de WhatsApp Cloud.
-   - `WHATSAPP_PHONE_NUMBER_ID`: ID del número de teléfono de WhatsApp Cloud.
+  - `WHATSAPP_PHONE_NUMBER_ID`: ID del número de teléfono de WhatsApp Cloud.
+  - `CRM_API_KEY` (opcional): Token que se incluirá en la cabecera `Authorization` al sincronizar con el CRM.
 
 2. Instala dependencias:
 
@@ -26,7 +27,17 @@ Servidor Express listo para desplegar en [Render](https://render.com) que expone
 
 - `GET /` devuelve un mensaje de estado.
 - `GET /webhook` gestiona la verificación de Meta (necesario para conectar el Webhook).
-- `POST /webhook` recibe mensajes entrantes y, si hay credenciales configuradas, responde con un mensaje de eco.
+- `POST /webhook` recibe mensajes entrantes, estructura la información relevante (contacto, contenido, adjuntos y estados) y la envía al CRM configurado. Si hay credenciales de WhatsApp, responde con un mensaje de eco.
+
+## Integración con CRM
+
+Cuando se recibe un evento de WhatsApp Cloud API, el servidor genera un payload con los datos necesarios para mostrarlos en un CRM:
+
+- Datos de contacto (WA ID y nombre de perfil).
+- Mensajes recibidos con contenido de texto, botones, interacciones y metadatos de archivos o ubicaciones.
+- Estados de mensajes (entregado, leído, etc.) con información de conversación y costos.
+
+El payload se enviará mediante `POST` en formato JSON al endpoint `https://script.google.com/macros/s/AKfycbzg0XHsW_fYiVhEcmp0WB3zmqQ9hV-usT0EDsnhwBlD8CSat3Gc_-lDOhMyGIUMjbcq/exec`. Puedes proteger la integración con `CRM_API_KEY` (se enviará como `Authorization: Bearer <token>`). Si no defines el token, la petición se enviará sin cabecera de autenticación.
 
 ## Despliegue en Render
 


### PR DESCRIPTION
## Summary
- hardcode the CRM synchronization target to the provided Google Apps Script endpoint and log it explicitly
- update the README to reflect that CRM events are posted directly to the fixed endpoint while keeping optional token support

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d43dde2f00832c9a90423776be0758